### PR TITLE
[Update]ユーザーコントローラの条件追加

### DIFF
--- a/app/controllers/users/cart_items_controller.rb
+++ b/app/controllers/users/cart_items_controller.rb
@@ -1,4 +1,6 @@
 class Users::CartItemsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :admin_block
 
   def index
     @cart_items = current_user.cart_items
@@ -45,6 +47,12 @@ class Users::CartItemsController < ApplicationController
 
   def cart_item_params
     params.require(:cart_item).permit(:user_id, :product_id, :amount)
+  end
+
+  def admin_block
+    if admin_signed_in?
+      redirect_to admins_path
+    end
   end
 
 end

--- a/app/controllers/users/deliveries_controller.rb
+++ b/app/controllers/users/deliveries_controller.rb
@@ -1,4 +1,6 @@
 class Users::DeliveriesController < ApplicationController
+  before_action :authenticate_user!
+  before_action :admin_block
 
   def index
     @delivery = Delivery.new
@@ -28,12 +30,18 @@ class Users::DeliveriesController < ApplicationController
   end
 
   def destroy_all
-    
+
   end
 
   private
     def delivery_params
       params.require(:delivery).permit(:user_id ,:zip_code, :address, :name)
     end
-  
+
+    def admin_block
+      if admin_signed_in?
+        redirect_to admins_path
+      end
+    end
+
 end

--- a/app/controllers/users/orders_controller.rb
+++ b/app/controllers/users/orders_controller.rb
@@ -1,4 +1,7 @@
 class Users::OrdersController < ApplicationController
+  before_action :authenticate_user!
+  before_action :admin_block
+
 
   def new
 
@@ -9,7 +12,7 @@ class Users::OrdersController < ApplicationController
   end
 
   def show
-    
+
   end
 
   def confirm
@@ -22,6 +25,14 @@ class Users::OrdersController < ApplicationController
 
   def thanks
 
+  end
+
+  private
+
+  def admin_block
+    if admin_signed_in?
+      redirect_to admins_path
+    end
   end
 
 end

--- a/app/controllers/users/products_controller.rb
+++ b/app/controllers/users/products_controller.rb
@@ -1,4 +1,5 @@
 class Users::ProductsController < ApplicationController
+  before_action :admin_block
 
   def top
 
@@ -23,6 +24,14 @@ class Users::ProductsController < ApplicationController
     if items.pluck(:product_id).include?(@cart_item.product_id)
       flash[:notice] = "商品はカートに追加済です"
       redirect_back(fallback_location: root_path)
+    end
+  end
+
+  private
+
+  def admin_block
+    if admin_signed_in?
+      redirect_to admins_path
     end
   end
 

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Users::RegistrationsController < Devise::RegistrationsController
+
+  before_action :admin_block
   # before_action :configure_sign_up_params, only: [:create]
   # before_action :configure_account_update_params, only: [:update]
 
@@ -59,4 +61,13 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # def after_inactive_sign_up_path_for(resource)
   #   super(resource)
   # end
+
+  private
+
+  def admin_block
+    if admin_signed_in?
+      redirect_to admins_path
+    end
+  end
+
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Users::SessionsController < Devise::SessionsController
+
+  before_action :admin_block
   # before_action :configure_sign_in_params, only: [:create]
 
   # GET /resource/sign_in
@@ -24,4 +26,13 @@ class Users::SessionsController < Devise::SessionsController
   # def configure_sign_in_params
   #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
   # end
+
+  private
+
+  def admin_block
+    if admin_signed_in?
+      redirect_to admins_path
+    end
+  end
+
 end

--- a/app/controllers/users/users_controller.rb
+++ b/app/controllers/users/users_controller.rb
@@ -1,6 +1,8 @@
 class Users::UsersController < ApplicationController
 
   before_action :set_user, except: [:withdraw, :withdraw_confirm]
+  before_action :authenticate_user!
+  before_action :admin_block
 
   # 退会済ユーザーは入れない様にする
   before_action :user_is_deleted
@@ -54,6 +56,12 @@ class Users::UsersController < ApplicationController
     if user_signed_in? && current_user.is_active == false
       flash[:notice] = "退会済ユーザーアカウントです"
       redirect_to root_path
+    end
+  end
+
+  def admin_block
+    if admin_signed_in?
+      redirect_to admins_path
     end
   end
 


### PR DESCRIPTION
・管理者がログインした場合、顧客側のページを踏んだら管理者トップページへリダイレクト 
・ログインしていないユーザーはサインイン、新規登録、商品ページ以外に入れない