### PR TITLE
Update user order

### DIFF
--- a/app/controllers/users/cart_items_controller.rb
+++ b/app/controllers/users/cart_items_controller.rb
@@ -4,6 +4,7 @@ class Users::CartItemsController < ApplicationController
 
   def index
     @cart_items = current_user.cart_items
+    @latest_order = current_user.orders.order(created_at: :desc).take
   end
 
   def create
@@ -18,7 +19,7 @@ class Users::CartItemsController < ApplicationController
     @cart_item.update(cart_item_params)
     @user = User.find(current_user.id)
     @cart_items = current_user.cart_items
-    render :index
+    redirect_to users_cart_items_path
   end
 
   def destroy

--- a/app/controllers/users/orders_controller.rb
+++ b/app/controllers/users/orders_controller.rb
@@ -33,6 +33,15 @@ class Users::OrdersController < ApplicationController
   def confirmation
     @order = Order.find(params[:id])
     @cart_items = current_user.cart_items
+    @latest_order = current_user.orders.order(created_at: :desc).take
+  end
+
+# お届け先編集画面(GET)
+  def edit
+  end
+
+# お届け先情報更新(PATCH/PUT)
+  def update
   end
 
 # 注文確定アクション(POST)
@@ -73,7 +82,11 @@ class Users::OrdersController < ApplicationController
     @order = Order.find(params[:id])
   end
 
-
+  def destroy
+    @order = Order.find(params[:id])
+    @order.destroy
+    redirect_to root_path
+  end
 
   private
   def order_params

--- a/app/controllers/users/orders_controller.rb
+++ b/app/controllers/users/orders_controller.rb
@@ -22,7 +22,6 @@ class Users::OrdersController < ApplicationController
       @order.address = @delivery.address
       @order.name = @delivery.name
     else
-      @delivery = current_user.deliveries.new
     end
 
     @order.total_price = 0
@@ -50,9 +49,14 @@ class Users::OrdersController < ApplicationController
           amount: cart_item.amount)
         @order_products.save!
       end
+      current_user.deliveries.create!(
+        zip_code: @order.zip_code,
+        address: @order.address,
+        name: @order.name
+      )
       current_user.cart_items.destroy_all
     end
-    redirect_to users_orders_thanks_path
+    redirect_to users_thanks_path
   end
 
 # サンクスページ(GET)

--- a/app/controllers/users/orders_controller.rb
+++ b/app/controllers/users/orders_controller.rb
@@ -24,7 +24,6 @@ class Users::OrdersController < ApplicationController
     else
     end
 
-    @order.total_price = 0
     @order.save
 
     redirect_to users_confirmation_order_path(@order)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,4 +26,9 @@ class User < ApplicationRecord
     count
   end
 
+  # 最新の注文が確定済みかどうか
+  def unconfirmed_order?
+    latest_order = orders.order(created_at: :desc).take
+    latest_order.order_products.present?
+  end
 end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -36,9 +36,16 @@
                 <li class="nav-list-item">
                   <%= link_to "カート",users_cart_items_path %>
                 </li>
-                <li class="nav-list-item">
-                  <%= link_to "ログアウト", destroy_user_session_path, method: :delete %>
-                </li>
+                <%# 注文未確定の商品がある場合はログアウト表示しない %>
+                <% if current_user.unconfirmed_order? %>
+                  <li class="nav-list-item">
+                    <%= link_to "ログアウト", destroy_user_session_path, method: :delete %>
+                  </li>
+                <% else %>
+                  <li class="nav-list-item">
+                    <%= link_to "注文確定", users_confirmation_order_path(current_user.orders.order(created_at: :desc).take)%>
+                  </li>
+                <% end %>
               <% else %>
                 <li class="nav-list-item">
                   <%= link_to "商品一覧",users_products_path %>

--- a/app/views/users/cart_items/index.html.erb
+++ b/app/views/users/cart_items/index.html.erb
@@ -55,8 +55,17 @@
     </div>
   </div>
   <div class="row">
-    <div class="col-xs-4 col-xs-offset-4">
-      <%= link_to "情報入力に進む", new_users_order_path, class:"btn btn-success btn-lg" %>
+    <div class="text-center">
+      <% if current_user.cart_items.present? %>
+        <% if current_user.unconfirmed_order? %>
+          <%= link_to "情報入力に進む", new_users_order_path, class: "btn btn-success" %>
+        <% else %>
+          <%= link_to "お届け先情報編集画面に進む", "#", class: "btn btn-primary"%>
+          <%= link_to "注文確認画面に進む", users_confirmation_order_path(@latest_order), class: "btn btn-success" %>
+        <% end %>
+      <% else %>
+        カート内は空です。
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/users/cart_items/index.html.erb
+++ b/app/views/users/cart_items/index.html.erb
@@ -1,14 +1,9 @@
 <div class="container">
-  <div class="row">
-    <div class="col-xs-8 col-xs-offset-2">
-    <h2>ショッピングカート</h2>
-    </div>
-  </div>
+  <h2>ショッピングカート</h2>
   <div class="row">
     <div class="col-xs-8 col-xs-offset-2">
       <div class="btn-box text-right">
       　<%= link_to "カートを空にする", users_cart_items_destroy_all_path, method: :delete, class:"btn btn-danger" %>
-        <%# URLのパスが思い通りにリンクされていない。後ほど修正 %>
       </div>
     <table class="table genre-index table-bordered">
       <thead>
@@ -53,18 +48,17 @@
         </tbody>
       </table>
     </div>
-  </div>
-  <div class="row">
     <div class="text-center">
       <% if current_user.cart_items.present? %>
         <% if current_user.unconfirmed_order? %>
           <%= link_to "情報入力に進む", new_users_order_path, class: "btn btn-success" %>
         <% else %>
-          <%= link_to "お届け先情報編集画面に進む", "#", class: "btn btn-primary"%>
+          <%= link_to "お届け先情報編集画面に進む", edit_users_order_path(@latest_order), class: "btn btn-primary"%>
           <%= link_to "注文確認画面に進む", users_confirmation_order_path(@latest_order), class: "btn btn-success" %>
+          <%= link_to "注文をやめる", users_order_path(@latest_order), method: :delete, class:"btn btn-danger"%>
         <% end %>
       <% else %>
-        カート内は空です。
+        カート内に商品は入っていません。
       <% end %>
     </div>
   </div>

--- a/app/views/users/orders/confirmation.html.erb
+++ b/app/views/users/orders/confirmation.html.erb
@@ -62,7 +62,9 @@
 
   <div class="row">
     <div class="text-center">
+    <%= link_to "お届け先を編集する", edit_users_order_path(@latest_order), class: "btn btn-primary" %>
     <%= link_to "購入を確定する", users_confirm_order_path(@order), method: :post, class:"btn btn-success" %>
+    <%= link_to "注文をやめる", users_order_path(@latest_order), method: :delete, class:"btn btn-danger"%>
     </div>
   </div>
 </div>

--- a/app/views/users/orders/edit.html.erb
+++ b/app/views/users/orders/edit.html.erb
@@ -1,4 +1,4 @@
-<%# 新規注文情報入力ページ %>
+<%# 注文情報編集ページ %>
 <div class="container">
   <div class="row">
     <div class="col-xs-8 col-xs-offset-2">
@@ -38,15 +38,15 @@
             <table>
               <tr>
                 <td>郵便番号（ハイフンなし）</td>
-                <td><%= f.text_field :zip_code %></td>
+                <td><%= f.text_field :zip_code, value:nil %></td>
               </tr>
               <tr>
                 <td>住所</td>
-                <td><%= f.text_field :address %></td>
+                <td><%= f.text_field :address, value:nil %></td>
               </tr>
               <tr>
                 <td>宛名</td>
-                <td><%= f.text_field :name %></td>
+                <td><%= f.text_field :name, value:nil %></td>
               </tr>
             </table>
           </div>

--- a/app/views/users/orders/index.html.erb
+++ b/app/views/users/orders/index.html.erb
@@ -16,7 +16,7 @@
       </thead>
       <tbody>
         <% @orders.each do |order| %>
-          <tr>
+          <tr class="text-center">
             <td><%= order.created_at.strftime("%Y/%m/%d") %></td>
             <td>
               <%= order.zip_code %><br>
@@ -28,20 +28,26 @@
                 <%= order_product.product.name %><br>
               <% end %>
             </td>
-            <td><%= order.total_price.to_s(:delimited) %>円</td>
-            <td>
-              <% case order.order_status when 0 %>
-                <span class="badge" style="background: red;">入金待ち</span>
-              <% when 1 %>
-                <span class="badge" style="background: orange;">入金確認</span>
-              <% when 2 %>
-                <span class="badge" style="background: green;">制作中</span>
-              <% when 3 %>
-                <span class="badge" style="background: blue;">制作中</span>
-              <% when 3 %>
-              <% end %>
-            </td>
-            <td><%= link_to "表示する", users_order_path(order), class:"btn btn-primary"%></td>
+            <% if order.order_products.present? %>
+              <td><%= order.total_price.to_s(:delimited) %>円</td>
+              <td class="col-xs-1">
+                <% case order.order_status when 0 %>
+                  <span class="badge" style="background: red;">入金待ち</span>
+                <% when 1 %>
+                  <span class="badge" style="background: orange;">入金確認</span>
+                <% when 2 %>
+                  <span class="badge" style="background: green;">制作中</span>
+                <% when 3 %>
+                  <span class="badge" style="background: blue;">制作中</span>
+                <% when 3 %>
+                <% end %>
+              </td>
+              <td class="col-xs-1"><%= link_to "表示する", users_order_path(order), class:"btn btn-primary"%></td>
+            <% else %>
+              <td></td>
+              <td><span class="badge" style="background: red">未確定</span></td>
+              <td></td>
+            <% end %>
           </tr>
         <% end %>
       </tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ Rails.application.routes.draw do
     resources :products, only: [:index, :show]
     resources :cart_items, only: [:index, :create, :update, :destroy]
     delete '/cart_items', to: 'cart_items#destroy_all', as: 'cart_items_destroy_all'
-    resources :orders, only: [:new, :create, :index, :show, :edit]
+    resources :orders
     # 注文確認画面
     get '/orders/:id/confirm', to: 'orders#confirmation',as: 'confirmation_order'
     # 注文確定アクション

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ Rails.application.routes.draw do
     resources :products, only: [:index, :show]
     resources :cart_items, only: [:index, :create, :update, :destroy]
     delete '/cart_items', to: 'cart_items#destroy_all', as: 'cart_items_destroy_all'
-    resources :orders, only: [:new, :create, :index, :show]
+    resources :orders, only: [:new, :create, :index, :show, :edit]
     # 注文確認画面
     get '/orders/:id/confirm', to: 'orders#confirmation',as: 'confirmation_order'
     # 注文確定アクション

--- a/db/migrate/20200430072912_create_orders.rb
+++ b/db/migrate/20200430072912_create_orders.rb
@@ -5,7 +5,7 @@ class CreateOrders < ActiveRecord::Migration[5.2]
       t.integer :user_id, null: false
       t.integer :pay_method, null: false, default: 0
       t.integer :postage, null: false, default: 800
-      t.integer :total_price, null: false
+      t.integer :total_price, null: false, default: 0
       t.string :zip_code, null: false
       t.string :address, null: false
       t.string :name, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -62,7 +62,7 @@ ActiveRecord::Schema.define(version: 2020_05_02_030156) do
     t.integer "user_id", null: false
     t.integer "pay_method", default: 0, null: false
     t.integer "postage", default: 800, null: false
-    t.integer "total_price", null: false
+    t.integer "total_price", default: 0, null: false
     t.string "zip_code", null: false
     t.string "address", null: false
     t.string "name", null: false


### PR DESCRIPTION
新規配送先を選んだ際に配送先に新しく追加する
未確定の注文があるかどうかで各ページ（カート・注文履歴・ヘッダー・注文確認ページ）の表示を変更
未確定の注文がある際にはログアウトできないように（ヘッダーの表示でのみ実現している）
未確定の注文がある際に注文情報編集ページに遷移できるようにした