### PR TITLE
Update users products index

### DIFF
--- a/app/views/users/cart_items/index.html.erb
+++ b/app/views/users/cart_items/index.html.erb
@@ -23,9 +23,11 @@
           <% @cart_items.each do |cart_item| %>
             <tr>
               <td class="col-xs-5">
-                <%= attachment_image_tag(cart_item.product, :image, :fill, 60, 40, fallback:"no_image.jpg", size: '60x40') %>
-                <%= cart_item.product.name %>
-              </td><%# 商品名 %>
+                <%= link_to users_product_path(cart_item.product) do %>
+                  <%= attachment_image_tag(cart_item.product, :image, :fill, 60, 40, fallback:"no_image.jpg", size: '60x40') %>
+                  <%= cart_item.product.name %>
+                <% end %>
+              </td>
               <td class="col-xs-2" align="right"><%= cart_item.product.taxed_price.to_s(:delimited) %>円</td><%# 単価(税込) %>
               <td class="col-xs-2" align="center">
                 <%= form_for [:users, cart_item] do |f| %>
@@ -42,7 +44,7 @@
         </tbody>
       </table>
       <div class="col-xs-8">
-        <%= link_to "買い物を続ける", root_path, class:"btn btn-primary" %>
+        <%= link_to "買い物を続ける", users_products_path, class:"btn btn-primary" %>
       </div>
       <div class="col-xs-4">
         <table class="table genre-index table-bordered">

--- a/app/views/users/products/index.html.erb
+++ b/app/views/users/products/index.html.erb
@@ -17,8 +17,11 @@
             <%# 商品価格 %>
             <li class="list-group-item">
               ¥<%= product.price %>
+              <% if current_user.present? && @cart_items.find_by(product_id: product.id).present? %>
+                (<%= @cart_items.find_by(product_id: product.id).amount %>個)
+              <% end %>
               <% if !product.is_active? %>
-                <span class="badge" style="background: blue;">売り切れ</span>
+                <span class="badge" style="background: red;">売り切れ</span>
               <% end %>
             </li>
             </ul>

--- a/app/views/users/products/index.html.erb
+++ b/app/views/users/products/index.html.erb
@@ -15,7 +15,12 @@
             <%# 商品名 %>
             <li class="list-group-item"><%= product.name %></li>
             <%# 商品価格 %>
-            <li class="list-group-item">¥<%= product.price %></li>
+            <li class="list-group-item">
+              ¥<%= product.price %>
+              <% if !product.is_active? %>
+                <span class="badge" style="background: blue;">売り切れ</span>
+              <% end %>
+            </li>
             </ul>
           <% end %>
         <% end %>

--- a/app/views/users/products/show.html.erb
+++ b/app/views/users/products/show.html.erb
@@ -10,11 +10,15 @@
             <h3><%= @product.name %></h3>
             <p><%= @product.description %></p>
             <h4><strong>¥<%= @product.price %></strong><small>（税込）</small></h4>
-            <% if current_user.present?%>
-              <%= form_for [:users, @cart_item], html: {class: "cart_btn"} do |f| %>
+            <% if current_user.present? %>
+              <% if @product.is_active? %>
+                <%= form_for [:users, @cart_item], html: {class: "cart_btn"} do |f| %>
                   <%= f.hidden_field :product_id, :value => @product.id %>
                   <%= f.select :amount,(1..10).to_a %>
                   <%= f.submit "カートに入れる", class:"btn btn-primary" %>
+                <% end %>
+              <% else %>
+                申し訳ございません。本日分は売り切れです。
               <% end %>
             <% end %>
         </div>

--- a/app/views/users/products/show.html.erb
+++ b/app/views/users/products/show.html.erb
@@ -10,10 +10,12 @@
             <h3><%= @product.name %></h3>
             <p><%= @product.description %></p>
             <h4><strong>¥<%= @product.price %></strong><small>（税込）</small></h4>
-            <%= form_for [:users, @cart_item], html: {class: "cart_btn"} do |f| %>
-                <%= f.hidden_field :product_id, :value => @product.id %>
-                <%= f.select :amount,(1..10).to_a %>
-                <%= f.submit "カートに入れる", class:"btn btn-primary" %>
+            <% if current_user.present?%>
+              <%= form_for [:users, @cart_item], html: {class: "cart_btn"} do |f| %>
+                  <%= f.hidden_field :product_id, :value => @product.id %>
+                  <%= f.select :amount,(1..10).to_a %>
+                  <%= f.submit "カートに入れる", class:"btn btn-primary" %>
+              <% end %>
             <% end %>
         </div>
     </div>


### PR DESCRIPTION
#55 #81 対応しました。
ジャンル/商品の組み合わせに対してユーザ側からのviewで
false/false => おすすめ、一覧に表示しない
false/true => おすすめ、一覧に表示しない
true/false => おすすめに表示しない、一覧（詳細）に売り切れとして表示
true/true => おすすめ、一覧（詳細）に表示する
という風に条件分けしました。
これは売り切れ商品も一覧としては表示する価値があるが、おすすめには表示してはならないという考えの元です。
また、カートに商品が入っている際の挙動を変更しました。
（詳細ページでは編集アクションになるように、一覧ページではカートの個数の表示）